### PR TITLE
Disable 'e'-key binding when exportable is set to false

### DIFF
--- a/app/components/satis/table/component_controller.js
+++ b/app/components/satis/table/component_controller.js
@@ -5,7 +5,7 @@ import { debounce } from "../../../../frontend/utils"
 import Sortable from "sortablejs"
 
 export default class extends ApplicationController {
-  static targets = ["header", "hiddenHeader", "column", "filterRow", "filter", "filterIndicator", "overlay", "modal"]
+  static targets = ["header", "hiddenHeader", "column", "filterRow", "filter", "filterIndicator", "overlay", "modal", "exportButton"]
   static values = {
     currentPage: Number,
     resetUrl: String,
@@ -188,12 +188,14 @@ export default class extends ApplicationController {
   }
 
   export(event) {
-    let turboFrame = this.element.closest("turbo-frame")
+    if (this.hasExportButtonTarget) {
+      let turboFrame = this.element.closest("turbo-frame")
 
-    let ourUrl = new URL(turboFrame.src, window.location.href)
-    let exportUrl = new URL(`/action_table/${encodeURIComponent(turboFrame.id)}/export.xlsx`, window.location.href)
-    exportUrl.search = ourUrl.search
-    window.location.replace(exportUrl)
+      let ourUrl = new URL(turboFrame.src, window.location.href)
+      let exportUrl = new URL(`/action_table/${encodeURIComponent(turboFrame.id)}/export.xlsx`, window.location.href)
+      exportUrl.search = ourUrl.search
+      window.location.replace(exportUrl)
+    }
   }
 
   openSearch(event) {

--- a/app/views/satis/tables/show.html.slim
+++ b/app/views/satis/tables/show.html.slim
@@ -111,7 +111,7 @@ turbo-frame id="#{params[:turbo_frame_id] || params[:table_name]}"
           - if params[:query].present?
             i.fa.fa-xmark.text-red-400 data-action="click->satis-table#reset"
           - if @table.class.exportable
-            i.fa.fa-file-export data-action="click->satis-table#export"
+            i.fa.fa-file-export data-action="click->satis-table#export" data-satis-table-target="exportButton"
 
         div
           = paginate @table.paged_scope, views_prefix: 'satis', theme: 'tables'


### PR DESCRIPTION
When setting `exportable false` in the ActionTable, the export button is not rendered.
That works as expected. What does not work as expected, is that you can still export the table using the `e`-key. 
This PR fixes this by checking if the export button is rendered before exporting.