### PR TITLE
Feature/dropdown issues fixes

### DIFF
--- a/app/components/satis/dropdown/component.html.slim
+++ b/app/components/satis/dropdown/component.html.slim
@@ -1,18 +1,9 @@
 div.satis-dropdown data-action="keydown->satis-dropdown#dispatch" data-controller="satis-dropdown" data-satis-dropdown-page-size-value=@page_size data-satis-dropdown-url-value=url data-satis-dropdown-url-params-value=(options[:url_params]||{}).to_json data-satis-dropdown-chain-to-value=@chain_to data-satis-dropdown-free-text-value=@free_text data-satis-dropdown-needs-exact-match-value="#{@needs_exact_match ? 'true' : 'false'}" data-satis-dropdown-is-multiple-value="#{options[:input_html][:multiple] || false}"
   - selection = []
   - if options[:input_html][:value].present?
-      - if options[:input_html][:value].is_a?(Array)
-        - selection = options_for_select(options[:input_html][:value].map{|item| [item, item, {selected: true}]})
-      - else
-        - selection = options_for_select(options[:input_html][:value].to_s.split(",").map{|item| [item, item, {selected: true}]})
-  - elsif form.object.present?
-    - if form.object.send(attribute).is_a?(String)
-      - selection = options_for_select(form.object.send(attribute).split(",").map{|item| [item, item, {selected: true}]})
-    - elsif form.object.send(attribute).is_a?(Array)
-      - selection = options_for_select(form.object.send(attribute).map{|item| [item, item, {selected: true}]})
-    - elsif form.object.respond_to?(:attributes)
-      - selection = options_for_select((form.object.attributes[attribute].nil? ? "" : form.object.attributes[attribute].send(value_method)).split(",").map{|item| [item, item, {selected: true}]})
+    - selection = options_for_select(options_array(options[:input_html][:value]))
   = form.select(attribute, selection, {}, options[:input_html].except(:multiple).reverse_merge(class: 'hidden', multiple: options[:input_html][:multiple] || false))
+
   .flex.flex-col
     div.hidden.py-1 data-satis-dropdown-target="pills"
     .flex.flex-col.items-center

--- a/app/components/satis/dropdown/component.rb
+++ b/app/components/satis/dropdown/component.rb
@@ -30,11 +30,11 @@ module Satis
 
         unless options[:input_html]["data-reflex"]
           actions = [options[:input_html]["data-action"], "change->satis-dropdown#display",
-            "focus->satis-dropdown#focus"].join(" ")
+                     "focus->satis-dropdown#focus"].join(" ")
         end
 
         options[:input_html].merge!("data-satis-dropdown-target" => "hiddenSelect",
-          "data-action" => actions)
+                                    "data-action" => actions)
 
         @block = block
         @page_size = options[:page_size] || 10
@@ -45,9 +45,31 @@ module Satis
         value = @options[:selected]
         value ||= @options.dig(:input_html, :value)
         value ||= form.object&.send(attribute)
-        value = value.id if value.respond_to? :id
-        # value = value.second if value.is_a?(Array) && value.size == 2 && value.first.casecmp?(value.second)
+
+        #value = value.id if value.respond_to?(:id)
+
+        value = value.second if value.is_a?(Array) && value.size == 2 && value.first.casecmp?(value.second)
         value
+      end
+
+      def options_array(obj)
+        return [[]] unless obj
+
+        if obj.is_a?(Array)
+          obj.filter_map {|item| option_value(item) }
+        else
+          [option_value(obj)]
+        end
+      end
+
+      def option_value(item)
+        if item.respond_to?(:id)
+          [nil, item.id, {selected: true}]
+        elsif item.is_a?(Array)
+          [item.second , item.first, {selected: true}]
+        elsif item.is_a?(String)
+          [nil, item, {selected: true}]
+        end
       end
 
       def placeholder

--- a/app/components/satis/dropdown/component.rb
+++ b/app/components/satis/dropdown/component.rb
@@ -19,6 +19,7 @@ module Satis
         @reset_button = options[:reset_button] || options[:include_blank]
 
         options[:input_html] ||= {}
+
         options[:input_html][:value] = hidden_value
 
         options[:input_html][:autofocus] ||= false
@@ -45,7 +46,7 @@ module Satis
         value ||= @options.dig(:input_html, :value)
         value ||= form.object&.send(attribute)
         value = value.id if value.respond_to? :id
-        value = value.second if value.is_a?(Array) && value.size == 2 && value.first.casecmp?(value.second)
+        # value = value.second if value.is_a?(Array) && value.size == 2 && value.first.casecmp?(value.second)
         value
       end
 

--- a/app/components/satis/dropdown/component_controller.js
+++ b/app/components/satis/dropdown/component_controller.js
@@ -579,8 +579,8 @@ export default class extends ApplicationController {
             let item = this.itemsTarget.querySelector('[data-satis-dropdown-item-value="' + opt.value + '"]');
             if (item) {
                 opt.text = item.getAttribute("data-satis-dropdown-item-text");
+                updated++;
             }
-            updated++;
         }
 
         if (!this.hasUrlValue || this.hiddenSelectTarget.options.length === updated) return Promise.resolve(false);

--- a/app/components/satis/dropdown/component_controller.js
+++ b/app/components/satis/dropdown/component_controller.js
@@ -76,15 +76,15 @@ export default class extends ApplicationController {
     this.resultsTarget.addEventListener("blur", this.boundBlur)
 
     window.addEventListener("click", this.boundClickedOutside)
+    this.refreshSelectionFromServer().then((changed) => {
+      this.setHiddenSelect();
+    })
 
     setTimeout(() => {
       this.getScrollParent(this.element)?.addEventListener("scroll", this.boundBlur)
     }, 500)
 
-    this.refreshSelectionFromServer().then((changed) => {
-      this.setHiddenSelect();
-      this.fetchResults();
-    })
+
   }
 
   getScrollParent(node) {
@@ -367,7 +367,7 @@ export default class extends ApplicationController {
 
   recordLastSearch() {
     let emptySearch = this.searchInputTarget.value === ""
-    this.lastSearch = emptySearch ? null : this.searchInputTarget.value
+    this.lastSearch = emptySearch ? "" : this.searchInputTarget.value
   }
 
   removePill(event) {
@@ -509,8 +509,8 @@ export default class extends ApplicationController {
 
       if (event != null && event.type == "input" && this.searchInputTarget.value.length >= 2) {
         ourUrl.searchParams.append("term", this.searchInputTarget.value)
-        this.recordLastSearch();
       }
+      this.recordLastSearch();
 
       ourUrl.searchParams.append("page", this.currentPage)
       ourUrl.searchParams.append("page_size", pageSize)

--- a/app/components/satis/dropdown/component_controller.js
+++ b/app/components/satis/dropdown/component_controller.js
@@ -231,6 +231,11 @@ export default class extends ApplicationController {
         if (!this.isMultipleValue) {
             this.hiddenSelectTarget.innerHTML = ""
 
+            var option = document.createElement("option")
+            option.text = ""
+            option.value = ""
+
+            this.hiddenSelectTarget.add(option)
             this.hiddenSelectTarget.dispatchEvent(new Event("change"))
         }
 

--- a/app/components/satis/dropdown/component_controller.js
+++ b/app/components/satis/dropdown/component_controller.js
@@ -6,746 +6,747 @@ import {createPopper} from "@popperjs/core"
 
 export default class extends ApplicationController {
 
-    static targets = [
-        "results",
-        "items",
-        "item",
-        "searchInput",
-        "resetButton",
-        "toggleButton",
-        "hiddenSelect",
-        "pills",
-        "pillTemplate",
-        "pill",
-    ]
-    static values = {
-        chainTo: String,
-        freeText: Boolean,
-        needsExactMatch: Boolean,
-        pageSize: Number,
-        url: String,
-        urlParams: Object,
-        isMultiple: Boolean,
+  static targets = [
+    "results",
+    "items",
+    "item",
+    "searchInput",
+    "resetButton",
+    "toggleButton",
+    "hiddenSelect",
+    "pills",
+    "pillTemplate",
+    "pill",
+  ]
+  static values = {
+    chainTo: String,
+    freeText: Boolean,
+    needsExactMatch: Boolean,
+    pageSize: Number,
+    url: String,
+    urlParams: Object,
+    isMultiple: Boolean,
+  }
+
+  connect() {
+    super.connect()
+
+    this.debouncedFetchResults = debounce(this.fetchResults.bind(this), 250)
+    this.debouncedLocalResults = debounce(this.localResults.bind(this), 250)
+    this.selectedIndex = -1
+
+    this.boundClickedOutside = this.clickedOutside.bind(this)
+    this.boundClickSearchInput = this.clickSearchInput.bind(this)
+    this.boundResetSearchInput = this.resetSearchInput.bind(this)
+    this.boundBlur = this.handleBlur.bind(this)
+
+    // To remember what the current page and last page were, we queried
+    this.currentPage = 1
+    this.lastPage = null
+    this.endPage = null
+
+    // To remember what the last search was we did
+    this.lastSearch = null
+
+    this.popperInstance = createPopper(this.element, this.resultsTarget, {
+      placement: "bottom-start",
+      strategy: "fixed",
+      modifiers: [
+        {name: "offset", options: {offset: [0, 1]}},
+        {
+          name: "flip",
+          options: {
+            boundary: this.element.closest(".sts-card"),
+          },
+        },
+        {
+          name: "preventOverflow",
+          options: {
+            boundary: this.element.closest(".sts-card"),
+          },
+        },
+        popperSameWidth,
+      ],
+    })
+
+    this.searchInputTarget.addEventListener("blur", this.boundBlur)
+    this.searchInputTarget.addEventListener("click", this.boundClickSearchInput)
+
+    this.toggleButtonTarget.addEventListener("blur", this.boundBlur)
+    this.resultsTarget.addEventListener("blur", this.boundBlur)
+
+    window.addEventListener("click", this.boundClickedOutside)
+
+    setTimeout(() => {
+      this.getScrollParent(this.element)?.addEventListener("scroll", this.boundBlur)
+    }, 500)
+
+    this.refreshSelectionFromServer().then((changed) => {
+      this.setHiddenSelect();
+      this.fetchResults();
+    })
+  }
+
+  getScrollParent(node) {
+    if (node == null) {
+      return null
     }
 
-    connect() {
-        super.connect()
+    let isScrollable = false
 
-        this.debouncedFetchResults = debounce(this.fetchResults.bind(this), 250)
-        this.debouncedLocalResults = debounce(this.localResults.bind(this), 250)
-        this.selectedIndex = -1
+    if (node instanceof Element) {
+      const vScrollValue = window.getComputedStyle(node).getPropertyValue("overflow-y")
 
-        this.boundClickedOutside = this.clickedOutside.bind(this)
-        this.boundClickSearchInput = this.clickSearchInput.bind(this)
-        this.boundResetSearchInput = this.resetSearchInput.bind(this)
-        this.boundBlur = this.handleBlur.bind(this)
-
-        // To remember what the current page and last page were, we queried
-        this.currentPage = 1
-        this.lastPage = null
-        this.endPage = null
-
-        // To remember what the last search was we did
-        this.lastSearch = null
-
-        this.popperInstance = createPopper(this.element, this.resultsTarget, {
-            placement: "bottom-start",
-            strategy: "fixed",
-            modifiers: [
-                {name: "offset", options: {offset: [0, 1]}},
-                {
-                    name: "flip",
-                    options: {
-                        boundary: this.element.closest(".sts-card"),
-                    },
-                },
-                {
-                    name: "preventOverflow",
-                    options: {
-                        boundary: this.element.closest(".sts-card"),
-                    },
-                },
-                popperSameWidth,
-            ],
-        })
-
-        this.searchInputTarget.addEventListener("blur", this.boundBlur)
-        this.searchInputTarget.addEventListener("click", this.boundClickSearchInput)
-
-        this.toggleButtonTarget.addEventListener("blur", this.boundBlur)
-        this.resultsTarget.addEventListener("blur", this.boundBlur)
-
-        window.addEventListener("click", this.boundClickedOutside)
-
-        setTimeout(() => {
-            this.getScrollParent(this.element)?.addEventListener("scroll", this.boundBlur)
-        }, 500)
-
-            this.refreshSelectionFromServer().then((changed) => {
-                this.setHiddenSelect();
-            })
+      isScrollable = vScrollValue == "auto" || vScrollValue == "scroll"
     }
 
-    getScrollParent(node) {
-        if (node == null) {
-            return null
-        }
+    if (isScrollable) {
+      return node
+    } else {
+      return node.parentNode == null ? node : this.getScrollParent(node.parentNode)
+    }
+  }
 
-        let isScrollable = false
+  disconnect() {
+    this.debouncedFetchResults = null
+    this.debouncedLocalResults = null
+    window.removeEventListener("click", this.boundClickedOutside)
+  }
 
-        if (node instanceof Element) {
-            const vScrollValue = window.getComputedStyle(node).getPropertyValue("overflow-y")
+  focus(event) {
+    this.searchInputTarget.focus()
+  }
 
-            isScrollable = vScrollValue == "auto" || vScrollValue == "scroll"
-        }
+  blur(event) {
+    this.handleBlur(event)
+  }
 
-        if (isScrollable) {
-            return node
-        } else {
-            return node.parentNode == null ? node : this.getScrollParent(node.parentNode)
-        }
+  handleBlur(event) {
+    if (!this.element.contains(event.relatedTarget) && this.resultsShown) {
+      this.hideResultsList()
+      if (event.target == this.searchInputTarget) {
+        this.boundResetSearchInput(event)
+      }
+    }
+  }
+
+  // Called on connect
+  // FIXME: Has code duplication with select
+  display(event) {
+    // Ignore if we triggered this change event
+    if (event?.detail?.src == "satis-dropdown") {
+      return
     }
 
-    disconnect() {
-        this.debouncedFetchResults = null
-        this.debouncedLocalResults = null
-        window.removeEventListener("click", this.boundClickedOutside)
+    this.refreshSelectionFromServer().then((changed) => {
+      this.setHiddenSelect();
+
+      if (!this.searchInputTarget.value && this.freeTextValue && this.hiddenSelectTarget.options.length > 0) {
+        this.searchInputTarget.value = this.hiddenSelectTarget.options[0].value
+      }
+
+      if (!this.hiddenSelectTarget.getAttribute("data-reflex"))
+        this.hiddenSelectTarget.dispatchEvent(new CustomEvent("change", {detail: {src: "satis-dropdown"}}))
+    })
+  }
+
+  // Called when scrolling in the resultsTarget
+  scroll(event) {
+    if (this.elementScrolled(this.resultsTarget)) {
+      this.fetchResults(event)
+    }
+  }
+
+  // User presses keys
+  dispatch(event) {
+    if (event.target.closest('[data-controller="satis-dropdown"]') != this.element) {
+      return
     }
 
-    focus(event) {
-        this.searchInputTarget.focus()
-    }
+    this.filterResultsChainTo()
 
-    blur(event) {
-        this.handleBlur(event)
-    }
+    switch (event.key) {
+      case "ArrowDown":
+        if (this.hasResults) {
+          this.showResultsList(event)
 
-    handleBlur(event) {
-        if (!this.element.contains(event.relatedTarget) && this.resultsShown) {
-            this.hideResultsList()
-            if (event.target == this.searchInputTarget) {
-                this.boundResetSearchInput(event)
-            }
+          this.moveDown()
         }
-    }
-
-    // Called on connect
-    // FIXME: Has code duplication with select
-    display(event) {
-        // Ignore if we triggered this change event
-        if (event?.detail?.src == "satis-dropdown") {
-            return
+        break
+      case "ArrowUp":
+        if (this.hasResults) {
+          this.moveUp()
         }
-
-        this.refreshSelectionFromServer().then((changed) => {
-            this.setHiddenSelect();
-
-            if (!this.searchInputTarget.value && this.freeTextValue && this.hiddenSelectTarget.options.length > 0) {
-                this.searchInputTarget.value = this.hiddenSelectTarget.options[0].value
-            }
-
-            if (!this.hiddenSelectTarget.getAttribute("data-reflex"))
-              this.hiddenSelectTarget.dispatchEvent(new CustomEvent("change", {detail: {src: "satis-dropdown"}}))
-        })
-    }
-
-    // Called when scrolling in the resultsTarget
-    scroll(event) {
-        if (this.elementScrolled(this.resultsTarget)) {
-            this.fetchResults(event)
-        }
-    }
-
-    // User presses keys
-    dispatch(event) {
-        if (event.target.closest('[data-controller="satis-dropdown"]') != this.element) {
-            return
-        }
-
-        this.filterResultsChainTo()
-
-        switch (event.key) {
-            case "ArrowDown":
-                if (this.hasResults) {
-                    this.showResultsList(event)
-
-                    this.moveDown()
-                }
-                break
-            case "ArrowUp":
-                if (this.hasResults) {
-                    this.moveUp()
-                }
-                break
-            case "Enter":
-                event.preventDefault()
-                this.select(event)
-
-                break
-            case "Escape":
-                if (this.resultsShown) {
-                    this.hideResultsList(event)
-                } else {
-                    this.reset(event)
-                }
-
-                break
-            default:
-                break
-        }
-
-        return true
-    }
-
-    // User enters text in the search field
-    search(event) {
-        if (this.hasUrlValue) {
-            this.debouncedFetchResults(event)
-        } else {
-            this.debouncedLocalResults(event)
-        }
-
-        if (this.searchInputTarget.value) {
-            this.searchInputTarget.closest(".bg-white").classList.add("warning")
-        } else {
-            this.searchInputTarget.closest(".bg-white").classList.remove("warning")
-        }
-
-        if (this.searchInputTarget.closest(".bg-white").classList.contains("warning") || !this.searchInputTarget.value) {
-            if (!this.isMultipleValue) {
-                this.hiddenSelectTarget.innerHTML = ""
-
-                if (this.freeTextValue && this.searchInputTarget.value) {
-                    var option = document.createElement("option")
-                    option.text = this.searchInputTarget.value
-                    option.value = this.searchInputTarget.value
-
-                    this.hiddenSelectTarget.add(option)
-                }
-            }
-        }
-    }
-
-    // User presses reset button
-    reset(event) {
-        if (!this.isMultipleValue) {
-            this.hiddenSelectTarget.innerHTML = ""
-
-            var option = document.createElement("option")
-            option.text = ""
-            option.value = ""
-
-            this.hiddenSelectTarget.add(option)
-            this.hiddenSelectTarget.dispatchEvent(new Event("change"))
-        }
-
-        this.searchInputTarget.value = null
-        this.lastSearch = null
-        this.lastPage = null
-        this.endPage = null
-
-        if (this.selectedItem) {
-            this.selectedItem.classList.remove("bg-primary-200")
-        }
-        this.selectedIndex = -1
-        if (this.hasUrlValue) {
-            this.itemsTarget.innerHTML = ""
-        }
-        this.hideResultsList()
-        this.itemTargets.forEach((item) => {
-            item.classList.remove("hidden")
-        })
-
-        if (event) {
-            event.preventDefault()
-        }
-
-        if (this.searchInputTarget.closest(".bg-white").classList.contains("warning")) {
-            this.searchInputTarget.closest(".bg-white").classList.remove("warning")
-        }
-
-        return false
-    }
-
-    // User selects an item using mouse
-    select(event) {
-        let dataDiv = event.target.closest('[data-satis-dropdown-target="item"]')
-        if (dataDiv == null) {
-            dataDiv = this.selectedItem
-        }
-        if (dataDiv == null) return
-
-        this.selectItem(dataDiv)
-
+        break
+      case "Enter":
         event.preventDefault()
-    }
+        this.select(event)
 
-    clickSearchInput(event) {
-        if (this.hasResults)
-            this.showResultsList(event)
-    }
-
-    selectItem(dataDiv) {
-        this.hideResultsList()
-
-        // Copy over data attributes on the item div to the hidden input
-        Array.prototype.slice.call(dataDiv.attributes).forEach((attr) => {
-            if (attr.name.startsWith("data") && !attr.name.startsWith("data-satis") && !attr.name.startsWith("data-action")) {
-                this.hiddenSelectTarget.setAttribute(attr.name, attr.value)
-            }
-        })
-
-        const selectedValue = dataDiv.getAttribute("data-satis-dropdown-item-value")
-        const selectedValueText = dataDiv.getAttribute("data-satis-dropdown-item-text")
-        var option = document.createElement("option")
-        option.text = selectedValueText
-        option.value = selectedValue
-        option.setAttribute("selected", true)
-
-        if (this.isMultipleValue) {
-            // add the item in the select if it is not already there
-            if (
-                !Array.from(this.hiddenSelectTarget.options)
-                    .map((opt) => opt.value)
-                    .includes(option.value)
-            ) {
-                this.hiddenSelectTarget.add(option)
-            }
-        } else {
-            // if the selection is empty or the value is different from the current one
-            if (this.hiddenSelectTarget.options.length === 0 || this.hiddenSelectTarget.options[0].value != option.value) {
-                this.hiddenSelectTarget.innerHTML = ""
-
-                this.searchInputTarget.value = option.text
-                this.recordLastSearch();
-
-                // add the item in the select
-                this.hiddenSelectTarget.add(option)
-            }
-        }
-
-        this.hiddenSelectTarget.dispatchEvent(new Event("change"))
-
-
-        if (this.searchInputTarget.closest(".bg-white").classList.contains("warning")) {
-            this.searchInputTarget.closest(".bg-white").classList.remove("warning")
-        }
-    }
-
-    setHiddenSelect() {
-        if (this.hiddenSelectTarget.options.length === 0) {
-            this.searchInputTarget.value = ""
-            this.pillsTarget.innerHTML = ""
-            this.pillsTarget.classList.add("hidden")
-            return true;
-        }
-
-
-        if (this.isMultipleValue) {
-            for (let i = 0; i < this.hiddenSelectTarget.options.length; i++) {
-                const opt = this.hiddenSelectTarget.options[i]
-                let pillExists = this.pillsTarget.querySelector(`[data-satis-dropdown-target="pill"] > button[data-satis-dropdown-id-param="${opt.value}"]`)
-                if (!pillExists) {
-                    // Add pill to selection
-                    const pillTemplate = this.pillTemplateTarget.content.firstElementChild.cloneNode(true)
-                    pillTemplate.prepend(opt.text)
-                    pillTemplate.querySelector("button").setAttribute("data-satis-dropdown-id-param", opt.value)
-                    this.pillsTarget.appendChild(pillTemplate)
-                }
-            }
-
-            this.searchInputTarget.value = ""
-            this.pillsTarget.classList.remove("hidden")
-        } else {
-            const opt = this.hiddenSelectTarget.options[0];
-            this.searchInputTarget.value = opt.text
-        }
-    }
-
-    // --- Helpers
-
-    recordLastSearch() {
-        let emptySearch = this.searchInputTarget.value === ""
-        this.lastSearch = emptySearch ? null : this.searchInputTarget.value
-    }
-
-    removePill(event) {
-        event.preventDefault()
-
-        this.hiddenSelectTarget.removeChild(this.hiddenSelectTarget.querySelector(`option[value="${event.params.id}"]`))
-        this.pillTargets
-            .find((pill) => pill.querySelector("button").getAttribute("data-satis-dropdown-id-param") == event.params.id)
-            ?.remove()
-
-        //this.hiddenSelectTarget.dispatchEvent(new Event("change"))
-    }
-
-    toggleResultsList(event) {
+        break
+      case "Escape":
         if (this.resultsShown) {
-            this.hideResultsList(event)
-
-            // Not sure what the intent is, but this causes Safari not to open a ticket
-            // } else if (this.element.contains(document.activeElement)) {
+          this.hideResultsList(event)
         } else {
-            this.filterResultsChainTo()
-            if (this.hasResults) {
-                this.showResultsList(event)
-            } else {
-                this.fetchResults(event)
-            }
+          this.reset(event)
         }
 
-        event.preventDefault()
-        return false
+        break
+      default:
+        break
     }
 
-    showResultsList(event) {
-        this.resultsTarget.classList.remove("hidden")
-        this.resultsTarget.setAttribute("data-show", "")
-        this.popperInstance.update()
-        this.toggleButtonTarget.querySelector(".fa-chevron-up").classList.remove("hidden")
-        this.toggleButtonTarget.querySelector(".fa-chevron-down").classList.add("hidden")
+    return true
+  }
+
+  // User enters text in the search field
+  search(event) {
+    if (this.hasUrlValue) {
+      this.debouncedFetchResults(event)
+    } else {
+      this.debouncedLocalResults(event)
     }
 
-    hideResultsList(event) {
-        this.resultsTarget.classList.add("hidden")
-        this.resultsTarget.removeAttribute("data-show")
-        this.toggleButtonTarget.querySelector(".fa-chevron-up").classList.add("hidden")
-        this.toggleButtonTarget.querySelector(".fa-chevron-down").classList.remove("hidden")
+    if (this.searchInputTarget.value) {
+      this.searchInputTarget.closest(".bg-white").classList.add("warning")
+    } else {
+      this.searchInputTarget.closest(".bg-white").classList.remove("warning")
     }
 
-    filterResultsChainTo() {
-        if (!this.chainToValue) {
-            return
+    if (this.searchInputTarget.closest(".bg-white").classList.contains("warning") || !this.searchInputTarget.value) {
+      if (!this.isMultipleValue) {
+        this.hiddenSelectTarget.innerHTML = ""
+
+        if (this.freeTextValue && this.searchInputTarget.value) {
+          var option = document.createElement("option")
+          option.text = this.searchInputTarget.value
+          option.value = this.searchInputTarget.value
+
+          this.hiddenSelectTarget.add(option)
         }
+      }
+    }
+  }
 
-        let chainToValue
-        let chainTo = this.hiddenSelectTarget.form.querySelector(`[name="${this.chainToValue}"]`)
-        if (chainTo) {
-            chainToValue = chainTo.value
-        }
+  // User presses reset button
+  reset(event) {
+    if (!this.isMultipleValue) {
+      this.hiddenSelectTarget.innerHTML = ""
 
-        this.itemTargets.forEach((item) => {
-            let itemChainToValue = item.getAttribute("data-chain")
-            let chainMatch = true
-            if (this.chainToValue || itemChainToValue) {
-                chainMatch = chainToValue == itemChainToValue
-            }
+      var option = document.createElement("option")
+      option.text = ""
+      option.value = ""
 
-            if (chainMatch) {
-                item.classList.remove("hidden")
-            } else {
-                item.classList.add("hidden")
-            }
-        })
+      this.hiddenSelectTarget.add(option)
+      this.hiddenSelectTarget.dispatchEvent(new Event("change"))
     }
 
-    localResults(event) {
-        if (this.searchInputTarget.value == this.lastSearch) {
-            return
-        }
+    this.searchInputTarget.value = null
+    this.lastSearch = null
+    this.lastPage = null
+    this.endPage = null
 
-        if (this.searchInputTarget.value.length < 2) {
-            return
-        }
+    if (this.selectedItem) {
+      this.selectedItem.classList.remove("bg-primary-200")
+    }
+    this.selectedIndex = -1
+    if (this.hasUrlValue) {
+      this.itemsTarget.innerHTML = ""
+    }
+    this.hideResultsList()
+    this.itemTargets.forEach((item) => {
+      item.classList.remove("hidden")
+    })
 
+    if (event) {
+      event.preventDefault()
+    }
+
+    if (this.searchInputTarget.closest(".bg-white").classList.contains("warning")) {
+      this.searchInputTarget.closest(".bg-white").classList.remove("warning")
+    }
+
+    return false
+  }
+
+  // User selects an item using mouse
+  select(event) {
+    let dataDiv = event.target.closest('[data-satis-dropdown-target="item"]')
+    if (dataDiv == null) {
+      dataDiv = this.selectedItem
+    }
+    if (dataDiv == null) return
+
+    this.selectItem(dataDiv)
+
+    event.preventDefault()
+  }
+
+  clickSearchInput(event) {
+    if (this.hasResults)
+      this.showResultsList(event)
+  }
+
+  selectItem(dataDiv) {
+    this.hideResultsList()
+
+    // Copy over data attributes on the item div to the hidden input
+    Array.prototype.slice.call(dataDiv.attributes).forEach((attr) => {
+      if (attr.name.startsWith("data") && !attr.name.startsWith("data-satis") && !attr.name.startsWith("data-action")) {
+        this.hiddenSelectTarget.setAttribute(attr.name, attr.value)
+      }
+    })
+
+    const selectedValue = dataDiv.getAttribute("data-satis-dropdown-item-value")
+    const selectedValueText = dataDiv.getAttribute("data-satis-dropdown-item-text")
+    var option = document.createElement("option")
+    option.text = selectedValueText
+    option.value = selectedValue
+    option.setAttribute("selected", true)
+
+    if (this.isMultipleValue) {
+      // add the item in the select if it is not already there
+      if (
+        !Array.from(this.hiddenSelectTarget.options)
+          .map((opt) => opt.value)
+          .includes(option.value)
+      ) {
+        this.hiddenSelectTarget.add(option)
+      }
+    } else {
+      // if the selection is empty or the value is different from the current one
+      if (this.hiddenSelectTarget.options.length === 0 || this.hiddenSelectTarget.options[0].value != option.value) {
+        this.hiddenSelectTarget.innerHTML = ""
+
+        this.searchInputTarget.value = option.text
         this.recordLastSearch();
 
-        this.itemTargets.forEach((item) => {
-            item.classList.remove("hidden")
-        })
+        // add the item in the select
+        this.hiddenSelectTarget.add(option)
+      }
+    }
 
-        this.filterResultsChainTo()
+    this.hiddenSelectTarget.dispatchEvent(new Event("change"))
 
-        let matches = []
-        this.itemTargets.forEach((item) => {
-            let text = item.getAttribute("data-satis-dropdown-item-text").toLowerCase()
-            let value = item.getAttribute("data-satis-dropdown-item-value").toLowerCase()
 
-            if (!item.classList.contains("hidden")) {
-                if (this.needsExactMatchValue && text === this.searchInputTarget.value.toLowerCase()) {
-                    matches = matches.concat(item)
-                } else if (!this.needsExactMatchValue && text.indexOf(this.searchInputTarget.value.toLowerCase()) >= 0) {
-                    matches = matches.concat(item)
-                } else {
-                    item.classList.add("hidden")
-                }
-            }
-        })
+    if (this.searchInputTarget.closest(".bg-white").classList.contains("warning")) {
+      this.searchInputTarget.closest(".bg-white").classList.remove("warning")
+    }
+  }
 
-        if (
-            matches.length == 1 &&
-            matches[0].getAttribute("data-satis-dropdown-item-text").toLowerCase().indexOf(this.lastSearch.toLowerCase()) >= 0
-        ) {
-            this.selectItem(matches[0].closest('[data-satis-dropdown-target="item"]'))
-        } else if (matches.length > 1) {
-            this.showResultsList(event)
+  setHiddenSelect() {
+    if (this.hiddenSelectTarget.options.length === 0) {
+      this.searchInputTarget.value = ""
+      this.pillsTarget.innerHTML = ""
+      this.pillsTarget.classList.add("hidden")
+      return true;
+    }
+
+
+    if (this.isMultipleValue) {
+      for (let i = 0; i < this.hiddenSelectTarget.options.length; i++) {
+        const opt = this.hiddenSelectTarget.options[i]
+        let pillExists = this.pillsTarget.querySelector(`[data-satis-dropdown-target="pill"] > button[data-satis-dropdown-id-param="${opt.value}"]`)
+        if (!pillExists) {
+          // Add pill to selection
+          const pillTemplate = this.pillTemplateTarget.content.firstElementChild.cloneNode(true)
+          pillTemplate.prepend(opt.text)
+          pillTemplate.querySelector("button").setAttribute("data-satis-dropdown-id-param", opt.value)
+          this.pillsTarget.appendChild(pillTemplate)
         }
+      }
+
+      this.searchInputTarget.value = ""
+      this.pillsTarget.classList.remove("hidden")
+    } else {
+      const opt = this.hiddenSelectTarget.options[0];
+      this.searchInputTarget.value = opt.text
     }
+  }
 
-    // Remote search
-    fetchResults(event) {
-        const promise = new Promise((resolve, reject) => {
-            if (
-                (this.searchInputTarget.value == this.lastSearch &&
-                    (this.currentPage == this.lastPage || this.currentPage == this.endPage)) ||
-                !this.hasUrlValue
-            ) {
-                return
-            }
+  // --- Helpers
 
-            if (this.searchInputTarget.value != this.lastSearch) {
-                this.currentPage = 1
-                this.endPage = null
-            }
+  recordLastSearch() {
+    let emptySearch = this.searchInputTarget.value === ""
+    this.lastSearch = emptySearch ? null : this.searchInputTarget.value
+  }
 
+  removePill(event) {
+    event.preventDefault()
 
-            this.lastPage = this.currentPage
+    this.hiddenSelectTarget.removeChild(this.hiddenSelectTarget.querySelector(`option[value="${event.params.id}"]`))
+    this.pillTargets
+      .find((pill) => pill.querySelector("button").getAttribute("data-satis-dropdown-id-param") == event.params.id)
+      ?.remove()
 
-            let ourUrl = this.normalizedUrl()
-            let pageSize = this.pageSizeValue
+    //this.hiddenSelectTarget.dispatchEvent(new Event("change"))
+  }
 
+  toggleResultsList(event) {
+    if (this.resultsShown) {
+      this.hideResultsList(event)
 
-            if (event != null && event.type == "input" && this.searchInputTarget.value.length >= 2) {
-                ourUrl.searchParams.append("term", this.searchInputTarget.value)
-                this.recordLastSearch();
-            }
-
-            ourUrl.searchParams.append("page", this.currentPage)
-            ourUrl.searchParams.append("page_size", pageSize)
-            if (this.needsExactMatchValue) {
-                ourUrl.searchParams.append("needs_exact_match", this.needsExactMatchValue)
-            }
-
-            this.fetchResultsWith(ourUrl).then((itemCount) => {
-                if (this.hasResults) {
-                    this.filterResultsChainTo()
-                    this.highLightSelected()
-                    this.showResultsList()
-
-                    if (
-                        this.nrOfItems == 1 &&
-                        this.itemTargets[0]
-                            .getAttribute("data-satis-dropdown-item-text")
-                            .toLowerCase()
-                            .indexOf(this.searchInputTarget.value.toLowerCase()) >= 0
-                    ) {
-                        this.selectItem(this.itemTargets[0].closest('[data-satis-dropdown-target="item"]'))
-                    } else if (this.nrOfItems == 1) {
-                        this.moveDown()
-                    }
-
-                    if (itemCount > 0) {
-                        this.currentPage += 1
-                    }
-                    if (itemCount < pageSize) {
-                        this.endPage = this.currentPage
-                    }
-
-                    resolve()
-                }
-            })
-        })
-        return promise
-    }
-
-    fetchResultsWith(ourUrl) {
-        const promise = new Promise((resolve, reject) => {
-            fetch(ourUrl.href, {}).then((response) => {
-                response.text().then((data) => {
-                    let tmpDiv = document.createElement("div")
-                    tmpDiv.innerHTML = data
-
-                    // Add needed items
-                    Array.from(tmpDiv.children).forEach((item) => {
-                        item.setAttribute("data-satis-dropdown-target", "item")
-                        item.setAttribute("data-action", "click->satis-dropdown#select")
-                    })
-
-                    if (this.currentPage == 1) {
-                        this.itemsTarget.innerHTML = tmpDiv.innerHTML
-                    } else {
-                        if (tmpDiv.innerHTML.length > 0) {
-                            this.itemsTarget.insertAdjacentHTML("beforeend", tmpDiv.innerHTML)
-                        }
-                    }
-
-                    resolve(tmpDiv.children.length)
-                })
-            })
-        })
-        return promise
-    }
-
-    refreshSelectionFromServer() {
-        let updated = 0;
-        for (let i = 0; i < this.hiddenSelectTarget.options.length; i++) {
-            let opt = this.hiddenSelectTarget.options[i];
-            let item = this.itemsTarget.querySelector('[data-satis-dropdown-item-value="' + opt.value + '"]');
-            if (item) {
-                opt.text = item.getAttribute("data-satis-dropdown-item-text");
-                updated++;
-            }
-        }
-
-        if (!this.hasUrlValue || this.hiddenSelectTarget.options.length === updated) return Promise.resolve(false);
-
-        const promise = new Promise((resolve, reject) => {
-            //  if (!this.hasUrlValue) return;
-
-            const ourUrl = this.normalizedUrl()
-
-            let selectedIds = Array.from(this.hiddenSelectTarget.options)
-                .map((opt) => opt.value)
-
-            // make sure we get all selected items
-            ourUrl.searchParams.append("page_size", selectedIds.length)
-            // parameters with [] will be converted to an array
-            if (selectedIds.length > 0)
-                selectedIds.forEach((id) => ourUrl.searchParams.append(selectedIds.length === 1 ? "id" : "id[]", id))
-
-            fetch(ourUrl.href, {}).then((response) => {
-                if (response.ok)
-                    response.text().then((data) => {
-                        let changed = false;
-                        let tmpDiv = document.createElement("div")
-                        tmpDiv.innerHTML = data
-
-                        for (let i = 0; i < this.hiddenSelectTarget.options.length; i++) {
-                            let opt = this.hiddenSelectTarget.options[i];
-                            let item = tmpDiv.querySelector('[data-satis-dropdown-item-value="' + opt.value + '"]')
-                            if (!item) {
-                                opt.remove()
-                                changed = true;
-                            } else {
-                                let text = item.getAttribute("data-satis-dropdown-item-text")
-
-                                if (opt.text != text) {
-                                    if(text === "")
-                                        opt.text = opt.id
-                                    else
-                                        opt.text = text
-
-                                    changed = true;
-                                }
-
-                                // Copy over data attributes on the item div to the hidden input
-                                Array.prototype.slice.call(item.attributes).forEach((attr) => {
-                                    if (attr.name.startsWith("data") && !attr.name.startsWith("data-satis") && !attr.name.startsWith("data-action")) {
-                                        this.hiddenSelectTarget.setAttribute(attr.name, attr.value)
-                                    }
-                                })
-                            }
-                        }
-
-                        resolve(changed)
-                    })
-            })
-        })
-        return promise
-    }
-
-    normalizedUrl() {
-        let ourUrl
-        try {
-            ourUrl = new URL(this.urlValue)
-        } catch (error) {
-            ourUrl = new URL(this.urlValue, window.location.href)
-        }
-
-        // Add searchParams based on url_params
-        const form = this.element.closest("form")
-        Object.entries(this.urlParamsValue).forEach((item) => {
-            let elm = form.querySelector(`[name='${item[1]}']`)
-            if (elm) {
-                ourUrl.searchParams.append(item[0], elm.value)
-            } else {
-                ourUrl.searchParams.append(item[0], item[1])
-            }
-        })
-
-        return ourUrl
-    }
-
-    get resultsShown() {
-        return this.resultsTarget.hasAttribute("data-show")
-    }
-
-    get nrOfItems() {
-        return this.itemTargets.filter((item) => {
-            return !item.classList.contains("hidden")
-        }).length
-    }
-
-    get hasResults() {
-        return this.nrOfItems > 0
-    }
-
-    increaseSelectedIndex() {
-        this.selectedIndex = this.selectedIndex + 1
-        if (this.selectedIndex >= this.nrOfItems) {
-            this.selectedIndex = this.nrOfItems - 1
-        }
-    }
-
-    decreaseSelectedIndex() {
-        this.selectedIndex = this.selectedIndex - 1
-        if (this.selectedIndex < 0) {
-            this.selectedIndex = 0
-        }
-    }
-
-    get selectedItem() {
-        return this.itemTargets.filter((item) => {
-            return !item.classList.contains("hidden")
-        })[this.selectedIndex]
-    }
-
-    lowLightSelected() {
-        if (this.selectedItem) {
-            this.selectedItem.classList.remove("bg-primary-200", "font-medium")
-        }
-    }
-
-    highLightSelected() {
-        if (this.selectedItem) {
-            this.selectedItem.classList.add("bg-primary-200", "font-medium")
-            this.selectedItem.scrollIntoView({behavior: "smooth", block: "nearest", inline: "start"})
-        }
-    }
-
-    moveDown() {
-        this.lowLightSelected()
-        this.increaseSelectedIndex()
-        this.highLightSelected()
-    }
-
-    moveUp() {
-        this.lowLightSelected()
-        this.decreaseSelectedIndex()
-        this.highLightSelected()
-    }
-
-    // clear search input and hide results
-    resetSearchInput(event) {
-        if (this.multiSelectValue || this.hiddenSelectTarget.options.length === 0) {
-            this.searchInputTarget.value = ""
-            return;
-        }
-
-        this.searchInputTarget.value = this.hiddenSelectTarget.options[0].text
+      // Not sure what the intent is, but this causes Safari not to open a ticket
+      // } else if (this.element.contains(document.activeElement)) {
+    } else {
+      this.filterResultsChainTo()
+      if (this.hasResults) {
+        this.showResultsList(event)
+      } else {
         this.fetchResults(event)
-        this.hideResultsList(event)
+      }
     }
 
-    clickedOutside(event) {
-        if (event.target.tagName == "svg" || event.target.tagName == "path") {
-            return
-        }
-        if (!this.element.contains(event.target)) {
-            if (this.resultsShown) {
-                this.hideResultsList()
-            }
-        }
+    event.preventDefault()
+    return false
+  }
+
+  showResultsList(event) {
+    this.resultsTarget.classList.remove("hidden")
+    this.resultsTarget.setAttribute("data-show", "")
+    this.popperInstance.update()
+    this.toggleButtonTarget.querySelector(".fa-chevron-up").classList.remove("hidden")
+    this.toggleButtonTarget.querySelector(".fa-chevron-down").classList.add("hidden")
+  }
+
+  hideResultsList(event) {
+    this.resultsTarget.classList.add("hidden")
+    this.resultsTarget.removeAttribute("data-show")
+    this.toggleButtonTarget.querySelector(".fa-chevron-up").classList.add("hidden")
+    this.toggleButtonTarget.querySelector(".fa-chevron-down").classList.remove("hidden")
+  }
+
+  filterResultsChainTo() {
+    if (!this.chainToValue) {
+      return
     }
+
+    let chainToValue
+    let chainTo = this.hiddenSelectTarget.form.querySelector(`[name="${this.chainToValue}"]`)
+    if (chainTo) {
+      chainToValue = chainTo.value
+    }
+
+    this.itemTargets.forEach((item) => {
+      let itemChainToValue = item.getAttribute("data-chain")
+      let chainMatch = true
+      if (this.chainToValue || itemChainToValue) {
+        chainMatch = chainToValue == itemChainToValue
+      }
+
+      if (chainMatch) {
+        item.classList.remove("hidden")
+      } else {
+        item.classList.add("hidden")
+      }
+    })
+  }
+
+  localResults(event) {
+    if (this.searchInputTarget.value == this.lastSearch) {
+      return
+    }
+
+    if (this.searchInputTarget.value.length < 2) {
+      return
+    }
+
+    this.recordLastSearch();
+
+    this.itemTargets.forEach((item) => {
+      item.classList.remove("hidden")
+    })
+
+    this.filterResultsChainTo()
+
+    let matches = []
+    this.itemTargets.forEach((item) => {
+      let text = item.getAttribute("data-satis-dropdown-item-text").toLowerCase()
+      let value = item.getAttribute("data-satis-dropdown-item-value").toLowerCase()
+
+      if (!item.classList.contains("hidden")) {
+        if (this.needsExactMatchValue && text === this.searchInputTarget.value.toLowerCase()) {
+          matches = matches.concat(item)
+        } else if (!this.needsExactMatchValue && text.indexOf(this.searchInputTarget.value.toLowerCase()) >= 0) {
+          matches = matches.concat(item)
+        } else {
+          item.classList.add("hidden")
+        }
+      }
+    })
+
+    if (
+      matches.length == 1 &&
+      matches[0].getAttribute("data-satis-dropdown-item-text").toLowerCase().indexOf(this.lastSearch.toLowerCase()) >= 0
+    ) {
+      this.selectItem(matches[0].closest('[data-satis-dropdown-target="item"]'))
+    } else if (matches.length > 1) {
+      this.showResultsList(event)
+    }
+  }
+
+  // Remote search
+  fetchResults(event) {
+    const promise = new Promise((resolve, reject) => {
+      if (
+        (this.searchInputTarget.value == this.lastSearch &&
+          (this.currentPage == this.lastPage || this.currentPage == this.endPage)) ||
+        !this.hasUrlValue
+      ) {
+        return
+      }
+
+      if (this.searchInputTarget.value != this.lastSearch) {
+        this.currentPage = 1
+        this.endPage = null
+      }
+
+
+      this.lastPage = this.currentPage
+
+      let ourUrl = this.normalizedUrl()
+      let pageSize = this.pageSizeValue
+
+
+      if (event != null && event.type == "input" && this.searchInputTarget.value.length >= 2) {
+        ourUrl.searchParams.append("term", this.searchInputTarget.value)
+        this.recordLastSearch();
+      }
+
+      ourUrl.searchParams.append("page", this.currentPage)
+      ourUrl.searchParams.append("page_size", pageSize)
+      if (this.needsExactMatchValue) {
+        ourUrl.searchParams.append("needs_exact_match", this.needsExactMatchValue)
+      }
+
+      this.fetchResultsWith(ourUrl).then((itemCount) => {
+        if (this.hasResults) {
+          this.filterResultsChainTo()
+          this.highLightSelected()
+          this.showResultsList()
+
+          if (
+            this.nrOfItems == 1 &&
+            this.itemTargets[0]
+              .getAttribute("data-satis-dropdown-item-text")
+              .toLowerCase()
+              .indexOf(this.searchInputTarget.value.toLowerCase()) >= 0
+          ) {
+            this.selectItem(this.itemTargets[0].closest('[data-satis-dropdown-target="item"]'))
+          } else if (this.nrOfItems == 1) {
+            this.moveDown()
+          }
+
+          if (itemCount > 0) {
+            this.currentPage += 1
+          }
+          if (itemCount < pageSize) {
+            this.endPage = this.currentPage
+          }
+
+          resolve()
+        }
+      })
+    })
+    return promise
+  }
+
+  fetchResultsWith(ourUrl) {
+    const promise = new Promise((resolve, reject) => {
+      fetch(ourUrl.href, {}).then((response) => {
+        response.text().then((data) => {
+          let tmpDiv = document.createElement("div")
+          tmpDiv.innerHTML = data
+
+          // Add needed items
+          Array.from(tmpDiv.children).forEach((item) => {
+            item.setAttribute("data-satis-dropdown-target", "item")
+            item.setAttribute("data-action", "click->satis-dropdown#select")
+          })
+
+          if (this.currentPage == 1) {
+            this.itemsTarget.innerHTML = tmpDiv.innerHTML
+          } else {
+            if (tmpDiv.innerHTML.length > 0) {
+              this.itemsTarget.insertAdjacentHTML("beforeend", tmpDiv.innerHTML)
+            }
+          }
+
+          resolve(tmpDiv.children.length)
+        })
+      })
+    })
+    return promise
+  }
+
+  refreshSelectionFromServer() {
+    let updated = 0;
+    for (let i = 0; i < this.hiddenSelectTarget.options.length; i++) {
+      let opt = this.hiddenSelectTarget.options[i];
+      let item = this.itemsTarget.querySelector('[data-satis-dropdown-item-value="' + opt.value + '"]');
+      if (item) {
+        opt.text = item.getAttribute("data-satis-dropdown-item-text");
+        updated++;
+      }
+    }
+
+    if (!this.hasUrlValue || this.hiddenSelectTarget.options.length === updated) return Promise.resolve(false);
+
+    const promise = new Promise((resolve, reject) => {
+      //  if (!this.hasUrlValue) return;
+
+      const ourUrl = this.normalizedUrl()
+
+      let selectedIds = Array.from(this.hiddenSelectTarget.options)
+        .map((opt) => opt.value)
+
+      // make sure we get all selected items
+      ourUrl.searchParams.append("page_size", selectedIds.length)
+      // parameters with [] will be converted to an array
+      if (selectedIds.length > 0)
+        selectedIds.forEach((id) => ourUrl.searchParams.append(selectedIds.length === 1 ? "id" : "id[]", id))
+
+      fetch(ourUrl.href, {}).then((response) => {
+        if (response.ok)
+          response.text().then((data) => {
+            let changed = false;
+            let tmpDiv = document.createElement("div")
+            tmpDiv.innerHTML = data
+
+            for (let i = 0; i < this.hiddenSelectTarget.options.length; i++) {
+              let opt = this.hiddenSelectTarget.options[i];
+              let item = tmpDiv.querySelector('[data-satis-dropdown-item-value="' + opt.value + '"]')
+              if (!item) {
+                opt.remove()
+                changed = true;
+              } else {
+                let text = item.getAttribute("data-satis-dropdown-item-text")
+
+                if (opt.text != text) {
+                  if (text === "")
+                    opt.text = opt.id
+                  else
+                    opt.text = text
+
+                  changed = true;
+                }
+
+                // Copy over data attributes on the item div to the hidden input
+                Array.prototype.slice.call(item.attributes).forEach((attr) => {
+                  if (attr.name.startsWith("data") && !attr.name.startsWith("data-satis") && !attr.name.startsWith("data-action")) {
+                    this.hiddenSelectTarget.setAttribute(attr.name, attr.value)
+                  }
+                })
+              }
+            }
+
+            resolve(changed)
+          })
+      })
+    })
+    return promise
+  }
+
+  normalizedUrl() {
+    let ourUrl
+    try {
+      ourUrl = new URL(this.urlValue)
+    } catch (error) {
+      ourUrl = new URL(this.urlValue, window.location.href)
+    }
+
+    // Add searchParams based on url_params
+    const form = this.element.closest("form")
+    Object.entries(this.urlParamsValue).forEach((item) => {
+      let elm = form.querySelector(`[name='${item[1]}']`)
+      if (elm) {
+        ourUrl.searchParams.append(item[0], elm.value)
+      } else {
+        ourUrl.searchParams.append(item[0], item[1])
+      }
+    })
+
+    return ourUrl
+  }
+
+  get resultsShown() {
+    return this.resultsTarget.hasAttribute("data-show")
+  }
+
+  get nrOfItems() {
+    return this.itemTargets.filter((item) => {
+      return !item.classList.contains("hidden")
+    }).length
+  }
+
+  get hasResults() {
+    return this.nrOfItems > 0
+  }
+
+  increaseSelectedIndex() {
+    this.selectedIndex = this.selectedIndex + 1
+    if (this.selectedIndex >= this.nrOfItems) {
+      this.selectedIndex = this.nrOfItems - 1
+    }
+  }
+
+  decreaseSelectedIndex() {
+    this.selectedIndex = this.selectedIndex - 1
+    if (this.selectedIndex < 0) {
+      this.selectedIndex = 0
+    }
+  }
+
+  get selectedItem() {
+    return this.itemTargets.filter((item) => {
+      return !item.classList.contains("hidden")
+    })[this.selectedIndex]
+  }
+
+  lowLightSelected() {
+    if (this.selectedItem) {
+      this.selectedItem.classList.remove("bg-primary-200", "font-medium")
+    }
+  }
+
+  highLightSelected() {
+    if (this.selectedItem) {
+      this.selectedItem.classList.add("bg-primary-200", "font-medium")
+      this.selectedItem.scrollIntoView({behavior: "smooth", block: "nearest", inline: "start"})
+    }
+  }
+
+  moveDown() {
+    this.lowLightSelected()
+    this.increaseSelectedIndex()
+    this.highLightSelected()
+  }
+
+  moveUp() {
+    this.lowLightSelected()
+    this.decreaseSelectedIndex()
+    this.highLightSelected()
+  }
+
+  // clear search input and hide results
+  resetSearchInput(event) {
+    if (this.multiSelectValue || this.hiddenSelectTarget.options.length === 0) {
+      this.searchInputTarget.value = ""
+      return;
+    }
+
+    this.searchInputTarget.value = this.hiddenSelectTarget.options[0].text
+    this.fetchResults(event)
+    this.hideResultsList(event)
+  }
+
+  clickedOutside(event) {
+    if (event.target.tagName == "svg" || event.target.tagName == "path") {
+      return
+    }
+    if (!this.element.contains(event.target)) {
+      if (this.resultsShown) {
+        this.hideResultsList()
+      }
+    }
+  }
 }


### PR DESCRIPTION
In component .rb from the dropdown we have a method that sets the value

```
def hidden_value
        value = @options[:selected]
        value ||= @options.dig(:input_html, :value)
        value ||= form.object&.send(attribute)
        value = value.id if value.respond_to? :id
        # value = value.second if value.is_a?(Array) && value.size == 2 && value.first.casecmp?(value.second)
        value
end
```

For normal forms rails gives us the "normal" converted to a model object. For the filters in action table we get a different kind of object, being ActionTableController::Filters with only the ID's available to us.
It seems for filters we only store the ID in the user data and there is no logic to convert this before/in this exact method causing the dropdowns HTML select object to only have options that contain the ID. 

This causes the follownig problems. 
- The name can be empty. If filters would have stored the name and id wed have to lookup the items beforehand and we need to know what model we are talking about and then create the options for the select based on that
- filters do not have the ability to lookup on ID. See,
```
 filter(:location, collection: lambda { |term|
          locations = Location.accessible
          locations = locations.where("name ~* :term", term: term) if term.present?
          locations = locations.to_a.push(CurrentLocation) if CurrentLocation.present?
          locations
        }) { |value| where(location_id: ((value == "current") ? CurrentLocation.location_id : value)) }

```
Before this PR The refreshSelectionFromServer method in the javascript from the dropdown component tries to lookup with the ID(s) (can be multiple ones) and this is not going to work unfortunately for filters.

Also instead of joining strings with '|' in the search query to have the parameter contain multiple values can be done with  something like
```
   if (selectedIds.length > 0)
                selectedIds.forEach((id) => ourUrl.searchParams.append(selectedIds.length === 1 ? "id" : "id[]", id))
```
Controllers will then merge multiple params with `id[]=` to an array.


This PR requires us to make some changes to action table in the `action_table_controller.rb` in the `filter_collection` method
to be able to search on ID to fetch the correct associated items. 
```
if @filter.collection.is_a?(Proc)
        if @filter.collection.parameters.size == 2
          @filter_items = false
          @items = @filter.collection.call(params[:term], params[:id])
        elsif @filter.collection.parameters.size == 1
          @filter_items = false
          @items = @filter.collection.call(params[:term])
        else
          @items = @filter.collection.call
        end
      else
        @items = @filter.collection
      end
```

And then in the filters we need to do something like (`application_table.rb` in OMS)
```
 filter(:location, collection: lambda { |term|
          locations = Location.accessible
          locations = locations.where("name ~* :term", term: term) if term.present?
          locations = locations.to_a.push(CurrentLocation) if CurrentLocation.present?
          locations
        }) { |value| where(location_id: ((value == "current") ? CurrentLocation.location_id : value)) }
```

Now we are able to fetch on ID. We are also able to do this in the select method in the products_controller.rb
That said the read me docs also state we need to be able to search on ID param aswell.
`components/satis/app/components/satis/dropdown/component.md`

It is either something like this or we need to find a way in which action_table is able to give us the actual model instead.
This can be 1 object or an array of the model as we support multi select. 
I am not sure if the form.object model is able to support arrays.

This also fixed some issues regarding the fetch method which causes the server to overload and pages to crash.