### PR TITLE
Bugfix/copyable shadow dom

### DIFF
--- a/frontend/elements/copyable_element.js
+++ b/frontend/elements/copyable_element.js
@@ -14,7 +14,7 @@ export default class SatisCopyable extends HTMLElement {
 
     this.input = document.createElement("input")
     this.input.style.position = "fixed"
-    this.input.style.top = 0
+    this.input.style.bottom = 0
     this.input.style.left = 0
     this.input.style.width = "1px"
     this.input.style.height = "1px"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "leaflet": "^1.7.1",
     "mousetrap": "^1.6.5",
     "sortablejs": "^1.14.0",
-    "tippy.js": "^6.3.1",
+    "tippy.js": "^6.3.7",
     "trix": "^2.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Dont break the shadow dom by adding an invisible item to the top, moved to bottom