### PR TITLE
Remove data from options once used.

### DIFF
--- a/lib/satis/forms/builder.rb
+++ b/lib/satis/forms/builder.rb
@@ -165,7 +165,7 @@ module Satis
       end
 
       def form_group(method, options = {}, &block)
-        tag.div(class: "form-group form-group-#{method}", data: options[:data]) do
+        tag.div(class: "form-group form-group-#{method}", data: options.delete(:data)) do
           safe_join [
             block.call,
             hint_text(options[:hint]),


### PR DESCRIPTION
When adding a `data: { controller: 'name' }` to an input the controller would be added to all child elements. Removing it after use in the wrapper now.