### PR TITLE
Fixed popper placement for empty table

### DIFF
--- a/app/components/satis/menu/component_controller.js
+++ b/app/components/satis/menu/component_controller.js
@@ -19,7 +19,7 @@ export default class extends ApplicationController {
             name: "flip",
             enabled: true,
             options: {
-              fallbackPlacements: ["bottom", "right"],
+              fallbackPlacements: ["bottom"],
               boundary: this.element.closest(".tbdy") || this.element.closest(".sts-card"),
             },
           },

--- a/app/components/satis/menu/component_controller.js
+++ b/app/components/satis/menu/component_controller.js
@@ -20,13 +20,13 @@ export default class extends ApplicationController {
             enabled: true,
             options: {
               fallbackPlacements: ["bottom", "right"],
-              boundary: this.element.closest(".table-wrp") || this.element.closest(".sts-card"),
+              boundary: this.element.closest(".tbdy") || this.element.closest(".sts-card"),
             },
           },
           {
             name: "preventOverflow",
             options: {
-              boundary: this.element.closest(".table-wrp") || this.element.closest(".sts-card"),
+              boundary: this.element.closest(".tbdy") || this.element.closest(".sts-card"),
             },
           },
         ],
@@ -121,8 +121,8 @@ export default class extends ApplicationController {
     if(!boundary) return
     const maxHeight = parseInt(window.getComputedStyle(boundary).maxHeight.replace("px", ""))
     const popperElement = this.popperInstance.state.elements.popper
-    if (boundary.offsetHeight < Math.min(popperElement.scrollHeight + 20, maxHeight)) {
-      boundary.style.minHeight = `${Math.min(popperElement.scrollHeight + 20, maxHeight)}px`;
+    if (boundary.offsetHeight < Math.min(popperElement.scrollHeight + 50, maxHeight)) {
+      boundary.style.minHeight = `${Math.min(popperElement.scrollHeight + 50, maxHeight)}px`;
     }
   }
 


### PR DESCRIPTION
popper for empty table was overlapping table header row, added fix for the same.
dependency PR - https://github.com/entdec/action_table/pull/92