### PR TITLE
feature/MakeDropdownTextDoubleClickable

### DIFF
--- a/app/components/satis/dropdown/component.css
+++ b/app/components/satis/dropdown/component.css
@@ -35,8 +35,10 @@
   @apply bg-white divide-gray-900 divide-opacity-25 shadow-gray-300 shadow-lg text-gray-900 text-opacity-75 dark:bg-gray-900 dark:shadow-gray-700 dark:shadow-lg dark:bg-opacity-75 dark:divide-gray-50 dark:divide-opacity-25 dark:text-gray-300;
 }
 
-.page_body .satis-dropdown .sts-dropdown .sts-dropdown-input{
+.satis-dropdown .sts-dropdown .sts-dropdown-input{
   @apply bg-white dark:bg-gray-900 dark:divide-gray-100;
+  pointer-events: all;
+  user-select: text;
 }
 
 .page_body .satis-dropdown .sts-dropdown-results-items{

--- a/app/components/satis/dropdown/component.html.slim
+++ b/app/components/satis/dropdown/component.html.slim
@@ -12,7 +12,7 @@ div.satis-dropdown data-action="keydown->satis-dropdown#dispatch" data-controlle
         .h-12.p-1.flex.rounded
           .flex.flex-auto.flex-wrap
             / Input where you can search
-            input.p-1.px-2.appearance-none.outline-none.w-full.sts-dropdown-input.text-gray-800.dark:text-gray-300 data-action="input->satis-dropdown#search" data-satis-dropdown-target="searchInput" placeholder=placeholder autofocus=options[:autofocus]
+            input.text.p-1.px-2.appearance-none.outline-none.w-full.sts-dropdown-input.text-gray-800.dark:text-gray-300 data-action="input->satis-dropdown#search" data-satis-dropdown-target="searchInput" placeholder=placeholder autofocus=options[:autofocus] ondblclick="this.select()"
           div
             / Reset button
             - unless @reset_button == false


### PR DESCRIPTION
Related to: https://github.com/boxture/server/issues/3272

Topbar dropdown is clickable wherever and double click selectable.
Page (table) dropdowns are now double clickable and this will select the entirety of the text the selection of specific place/drag selecting is blocked by the drag function on the dropdowns themselves, however changing cursor position can be done with arrows

