### PR TITLE
bug/SatisDialogDoesntAffectSidebar

### DIFF
--- a/app/components/satis/page/component.html.slim
+++ b/app/components/satis/page/component.html.slim
@@ -18,5 +18,5 @@ html lang="en"
             .mt-4
               .max-w.mx-auto.px-4.sm:px-4.md:px-4
                 = body
-      .sidebar
-        == sidebar
+        .sidebar
+          == sidebar


### PR DESCRIPTION
Moving the sidebar to inside the page_bg will allow it to get triggered along with the rest of the page
https://github.com/boxture/server/issues/4407